### PR TITLE
Fix spec text and point to local CSS and JS files

### DIFF
--- a/spec/constructor-properties.html
+++ b/spec/constructor-properties.html
@@ -23,8 +23,11 @@
       1. Let _subscriber_ be a new built-in function object as defined in Observable.from Delegating Functions.
       1. Set _subscriber_'s [[Observable]] internal slot to _observable_.
     1. Else,
+      1. Let _iteratorMethod_ be ? GetMethod(_x_, `@@observable`).
+      1. If _iteratorMethod_ is *undefined*, throw a *TypeError* exception.
       1. Let _subscriber_ be a new built-in function object as defined in Observable.from Iteration Functions.
-      1. Set _subscriber_'s [[Items]] internal slot to _x_.
+      1. Set _subscriber_'s [[Iterable]] internal slot to _x_.
+      1. Set _subscriber_'s [[IteratorMethod]] internal slot to _iteratorMethod_.
     1. Return Construct(_C_, « ‍_subscriber_ »).
   </emu-alg>
 
@@ -46,13 +49,14 @@
   <emu-clause id="observable-from-iteration-functions">
     <h1>Observable.from Iteration Functions</h1>
 
-    <p>An Observable.from iteration function is an anonymous built-in function that has an [[Items]] internal slot.</p>
+    <p>An Observable.from iteration function is an anonymous built-in function that has [[Iterable]] and [[IteratorFunction]] internal slots.</p>
 
     <p>When an Observable.from iteration function is called with argument _observer_, the following steps are taken:</p>
 
     <emu-alg>
-      1. Let _items_ be the value of the [[Items]] internal slot of _F_.
-      1. Let _iterator_ be ? GetIterator(_items_).
+      1. Let _iterable_ be the value of the [[Iterable]] internal slot of _F_.
+      1. Let _iteratorMethod_ be the value of the [[IteratorMethod]] internal slot of _F_.
+      1. Let _iterator_ be ? GetIterator(_items_, _iteratorMethod_).
       1. Repeat
         1. Let _next_ be ? IteratorStep(_iterator_).
         1. If _next_ is *false*, then
@@ -83,7 +87,7 @@
   <emu-clause id="observable-of-subscriber-functions">
     <h1>Observable.of Subscriber Functions</h1>
 
-    <p>An Observable.of subscriber function is an anonymous built-in function that has a [[Items]] internal slot.</p>
+    <p>An Observable.of subscriber function is an anonymous built-in function that has an [[Items]] internal slot.</p>
 
     <p>When an Observable.of subscriber function is called with argument _observer_, the following steps are taken:</p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -8,9 +8,8 @@ location: https://github.com/zenparsing/es-observable
 copyright: false
 contributors: Kevin Smith
 </pre>
-<script src="https://bterlson.github.io/ecmarkup/ecmarkup.js" defer></script>
-<link rel="stylesheet" href="https://bterlson.github.io/ecmarkup/elements.css">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/solarized_light.min.css">
+<script src="ecmarkup.js" defer></script>
+<link rel="stylesheet" href="ecmarkup.css">
 
 <emu-clause id="observable-constructor">
   <h1>The Observable Constructor</h1>


### PR DESCRIPTION
This commit also fixes the specification of `Observable.from` to match the polyfill.