### PR TITLE
Complete has no arguments

### DIFF
--- a/es-observable-tests/es-observable-tests.js
+++ b/es-observable-tests/es-observable-tests.js
@@ -1823,7 +1823,7 @@ exports["default"] = {
         testMethodProperty(test, Object.getPrototypeOf(observer), "complete", {
             configurable: true,
             writable: true,
-            length: 1
+            length: 0
         });
     },
 


### PR DESCRIPTION
Pretty sure the test should be asserting that `complete` has no arguments rather than 1.