### PR TITLE
Close subscription on error/complete

### DIFF
--- a/spec/subscription-observer.html
+++ b/spec/subscription-observer.html
@@ -61,6 +61,7 @@
       1. Let _subscription_ be the value of _O_'s [[Subscription]] internal slot.
       1. If SubscriptionClosed(_subscription_) is *true*, return *undefined*.
       1. Let _observer_ be the value of _subscription_'s [[Observer]] internal slot.
+      1. Set _subscription_'s [[Observer]] internal slot to *undefined*.
       1. Assert: Type(_observer_) is Object.
       1. Let _errorMethodResult_ be GetMethod(_observer_, `"error"`).
       1. If _errorMethodResult_.[[Type]] is ~normal~, then
@@ -83,6 +84,7 @@
       1. Let _subscription_ be the value of _O_'s [[Subscription]] internal slot.
       1. If SubscriptionClosed(_subscription_) is *true*, return *undefined*.
       1. Let _observer_ be the value of _subscription_'s [[Observer]] internal slot.
+      1. Set _subscription_'s [[Observer]] internal slot to *undefined*.
       1. Assert: Type(_observer_) is Object.
       1. Let _completeMethodResult_ be GetMethod(_observer_, `"complete"`).
       1. If _completeMethodResult_.[[Type]] is ~normal~, then


### PR DESCRIPTION
My understanding is that a subscription is supposed to be automatically closed on `error`/`complete` ([source](https://github.com/tc39/proposal-observable/blob/14007f54b20a3cc49d29e3a9c2b764c3a2c4acdb/src/Observable.js#L180)) but the spec doesn't seem to enforce this.

I think this is the right way of stating it.