### PR TITLE
README: Added fate-observable implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ and applications to share a common push-based stream protocol.
 
 - [RxJS 5](https://github.com/ReactiveX/RxJS)
 - [zen-observable](https://github.com/zenparsing/zen-observable)
+- [fate-observable](https://github.com/shanewholloway/node-fate-observable)
 
 ### Running Tests ###
 


### PR DESCRIPTION
Adding README entry for [fate-observable](https://github.com/shanewholloway/node-fate-observable) to list of ES Observable spec implementations.