### PR TITLE
Make npm test work for easy test running

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "name": "es-observable",
   "private": true,
+  "scripts": {
+    "test": "babel-node --plugins transform-es2015-modules-commonjs run-tests.js"
+  },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "moon-unit": "^0.2.1"
   }
 }

--- a/test/from.js
+++ b/test/from.js
@@ -27,7 +27,7 @@ export default {
 
         let usesThis = false;
 
-        Observable.from.call(_=> usesThis = true, []);
+        Observable.from.call(function(_) { usesThis = true; }, []);
         test._("Observable.from will use the 'this' value if it is callable")
         .equals(usesThis, true);
     },

--- a/test/of.js
+++ b/test/of.js
@@ -17,7 +17,7 @@ export default {
 
         let usesThis = false;
 
-        Observable.of.call(_=> usesThis = true);
+        Observable.of.call(function(_) { usesThis = true; });
         test._("Observable.of will use the 'this' value if it is callable")
         .equals(usesThis, true);
     },


### PR DESCRIPTION
Runs the tests using babel-cli and babel-plugin-transform-es2015-modules-commonjs.

Relies on zenparsing/moon-unit#1 (or manually patching the npm installed node_modules/moon-unit/package.json to include `"main": "./build/moon-unit.js"`.)