### PR TITLE
Transpile to commonjs modules; add main and version to enable requiring.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+    "plugins": ["transform-es2015-modules-commonjs"]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,3 @@
 .DS_Store
 _*
-node_modules
 ObservableTests
-commonjs

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "es-observable",
   "private": true,
   "scripts": {
-    "test": "babel-node --plugins transform-es2015-modules-commonjs run-tests.js"
+    "test": "babel-node run-tests.js",
+    "prepare": "babel -d commonjs/src/ src/ && babel -d commonjs/test/ test/ && babel -d commonjs/ run-tests.js"
   },
+  "main": "commonjs/src/Observable.js",
+  "version": "0.3.0",
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
-    "moon-unit": "^0.2.1"
+    "moon-unit": "^0.2.2"
   }
 }


### PR DESCRIPTION
This allows developers to add devDependencies on this repo (along with moon-unit) and run the transpiled spec tests against their Observable implementation.