### PR TITLE
Add test to avoid constructor as function

### DIFF
--- a/test/constructor.js
+++ b/test/constructor.js
@@ -1,6 +1,15 @@
 import { testMethodProperty } from "./helpers.js";
 
 export default {
+    
+    "Observable should be called as a constructor with new operator" (test, { Observable }) {
+
+        test
+        ._("It cannot be called as a function")
+        .throws(_ => Observable(function() {}), TypeError)
+        .throws(_ => Observable.call({}, function() {}), TypeError)
+        ;
+    },
 
     "Argument types" (test, { Observable }) {
 


### PR DESCRIPTION
> https://tc39.github.io/proposal-observable/#observable
> If NewTarget is `undefined`, throw a `TypeError` exception.

`TypeError` will be thrown in ES5 code transpiled by Babel.

https://babeljs.io/repl/#?babili=false&browsers=&build=&builtIns=false&code_lz=MYGwhgzhAEBiD29oG8C-Q&debug=false&circleciRepo=&evaluate=false&lineWrap=false&presets=es2015&targets=&version=6.26.0

But, it will not in general ES5 code...