### PR TITLE
WIP: Spec fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,20 +99,20 @@ require("es-observable-tests").runTests(MyObservable);
 
 An Observable represents a sequence of values which may be observed.
 
-```js
-interface Observable {
-
+```ts
+class Observable {
+    // Creates an observable from a callback
     constructor(subscriber : SubscriberFunction);
 
     // Subscribes to the sequence with an observer
     subscribe(observer : Observer) : Subscription;
 
     // Subscribes to the sequence with callbacks
-    subscribe(onNext : Function,
-              onError? : Function,
-              onComplete? : Function) : Subscription;
+    subscribe(onNext : (value) => void,
+              onError? : (errorValue) => void,
+              onComplete? : () => void) : Subscription;
 
-    // Returns itself
+    // Returns itself, but subclasses can override
     [Symbol.observable]() : Observable;
 
     // Converts items to an Observable
@@ -120,19 +120,18 @@ interface Observable {
 
     // Converts an observable or iterable to an Observable
     static from(observable) : Observable;
-
 }
 
 interface Subscription {
-
     // Cancels the subscription
     unsubscribe() : void;
 
     // A boolean value indicating whether the subscription is closed
-    get closed() : Boolean;
+    get closed() : boolean;
 }
 
-function SubscriberFunction(observer: SubscriptionObserver) : (void => void)|Subscription;
+type SubscriberFunction =
+    (observer : SubscriptionObserver) => (() => void) | Subscription;
 ```
 
 #### Observable.of ####
@@ -159,8 +158,8 @@ Observable.of("red", "green", "blue").subscribe({
 `Observable.from` converts its argument to an Observable.
 
 - If the argument has a `Symbol.observable` method, then it returns the result of
-  invoking that method.  If the resulting object is not an instance of Observable,
-  then it is wrapped in an Observable which will delegate subscription.
+  invoking that method.  If the resulting object is not a direct instance of Observable,
+  then it is wrapped into an Observable which will delegate subscription.
 - Otherwise, the argument is assumed to be an iterable and the iteration values are
   delivered synchronously when `subscribe` is called.
 
@@ -216,20 +215,19 @@ argument to **subscribe**.
 
 All methods are optional.
 
-```js
+```ts
 interface Observer {
-
     // Receives the subscription object when `subscribe` is called
-    start(subscription : Subscription);
+    start(subscription : Subscription) : void;
 
     // Receives the next value in the sequence
-    next(value);
+    next(value) : void;
 
     // Receives the sequence error
-    error(errorValue);
+    error(errorValue) : void;
 
     // Receives a completion notification
-    complete();
+    complete() : void;
 }
 ```
 
@@ -238,19 +236,18 @@ interface Observer {
 A SubscriptionObserver is a normalized Observer which wraps the observer object supplied to
 **subscribe**.
 
-```js
+```ts
 interface SubscriptionObserver {
-
     // Sends the next value in the sequence
-    next(value);
+    next(value) : void;
 
     // Sends the sequence error
-    error(errorValue);
+    error(errorValue) : void;
 
     // Sends the completion notification
-    complete();
+    complete() : void;
 
     // A boolean value indicating whether the subscription is closed
-    get closed() : Boolean;
+    get closed() : boolean;
 }
 ```

--- a/spec/constructor-properties.html
+++ b/spec/constructor-properties.html
@@ -13,21 +13,21 @@
 
   <emu-alg>
     1. Let _C_ be the *this* value.
-    1. If IsConstructor(C) is *false*, let _C_ be %Observable%.
+    1. If IsConstructor(_C_) is *false*, let _C_ be %Observable%.
     1. Let _observableMethod_ be ? GetMethod(_x_, `@@observable`).
     1. If _observableMethod_ is not *undefined*, then
-      1. Let _observable_ be ? Call(_observableMethod_, _x_, «‍ »).
+      1. Let _observable_ be ? Call(_observableMethod_, _x_, « »).
       1. If Type(_observable_) is not Object, throw a *TypeError* exception.
       1. Let _constructor_ be ? Get(_observable_, `"constructor"`).
       1. If SameValue(_constructor_, _C_) is *true*, return _observable_.
       1. Let _subscriber_ be a new built-in function object as defined in Observable.from Delegating Functions.
-      1. Set _subscriber_'s [[Observable]] internal slot to _observable_.
+      1. Set _subscriber_.[[Observable]] to _observable_.
     1. Else,
-      1. Let _iteratorMethod_ be ? GetMethod(_x_, `@@observable`).
+      1. Let _iteratorMethod_ be ? GetMethod(_x_, `@@iterator`).
       1. If _iteratorMethod_ is *undefined*, throw a *TypeError* exception.
       1. Let _subscriber_ be a new built-in function object as defined in Observable.from Iteration Functions.
-      1. Set _subscriber_'s [[Iterable]] internal slot to _x_.
-      1. Set _subscriber_'s [[IteratorMethod]] internal slot to _iteratorMethod_.
+      1. Set _subscriber_.[[Iterable]] to _x_.
+      1. Set _subscriber_.[[IteratorMethod]] to _iteratorMethod_.
     1. Return Construct(_C_, « ‍_subscriber_ »).
   </emu-alg>
 
@@ -39,7 +39,9 @@
     <p>When an Observable.from delegating function is called with argument _observer_, the following steps are taken:</p>
 
     <emu-alg>
-      1. Let _observable_ be the value of the [[Observable]] internal slot of _F_.
+      1. Assert: _F_ has an [[Observable]] internal slot whose value is an Object.
+      1. If Type(_observer_) is not Object, throw a *TypeError* exception.
+      1. Let _observable_ be _F_.[[Observable]].
       1. Return Invoke(_observable_, `"subscribe"`, « ‍_observer_ »).
     </emu-alg>
 
@@ -49,24 +51,29 @@
   <emu-clause id="observable-from-iteration-functions">
     <h1>Observable.from Iteration Functions</h1>
 
-    <p>An Observable.from iteration function is an anonymous built-in function that has [[Iterable]] and [[IteratorFunction]] internal slots.</p>
+    <p>An Observable.from iteration function is an anonymous built-in function that has [[Iterable]] and [[IteratorMethod]] internal slots.</p>
 
     <p>When an Observable.from iteration function is called with argument _observer_, the following steps are taken:</p>
 
     <emu-alg>
-      1. Let _iterable_ be the value of the [[Iterable]] internal slot of _F_.
-      1. Let _iteratorMethod_ be the value of the [[IteratorMethod]] internal slot of _F_.
-      1. Let _iterator_ be ? GetIterator(_items_, _iteratorMethod_).
-      1. Let _subscription_ be the value of _observer_'s [[Subscription]] internal slot.
+      1. Assert: _F_ has an [[Iterable]] internal slot whose value is an Object.
+      1. Assert: _F_ has an [[IteratorMethod]] internal slot whose value is an Object.
+      1. Assert: IsCallable(_F_.[[IteratorMethod]]) is *true*.
+      1. If Type(_observer_) is not Object, throw a *TypeError* exception.
+      1. Let _iterable_ be _F_.[[Iterable]].
+      1. Let _iteratorMethod_ be _F_.[[IteratorMethod]].
+      1. Let _iterator_ be ? GetIterator(_iterable_, ~sync~, _iteratorMethod_).
       1. Repeat
+        1. Let _closed_ be ? ToBoolean(? GetV(_observer_, `"closed"`)).
+        1. If _closed_ is *true*, then
+          1. Perform ? IteratorClose(_iterator_, *undefined*).
+          1. Return *undefined*.
         1. Let _next_ be ? IteratorStep(_iterator_).
         1. If _next_ is *false*, then
-          1. Perform ! Invoke(_observer_, `"complete"`, «‍ »).
+          1. Perform ? Invoke(_observer_, `"complete"`, « »).
           1. Return *undefined*.
         1. Let _nextValue_ be ? IteratorValue(_next_).
-        1. Perform ! Invoke(_observer_, `"next"`, « ‍_nextValue_ »).
-        1. If SubscriptionClosed(_subscription_) is *true*, then
-          1. Return ? IteratorClose(_iterator_, *undefined*).
+        1. Perform ? Invoke(_observer_, `"next"`, « ‍_nextValue_ »).
     </emu-alg>
 
     <p>The `length` property of an Observable.from iteration function is `1`.</p>
@@ -79,9 +86,10 @@
 
   <emu-alg>
     1. Let _C_ be the *this* value.
-    1. If IsConstructor(C) is *false*, let _C_ be %Observable%.
+    1. If IsConstructor(_C_) is *false*, let _C_ be %Observable%.
     1. Let _subscriber_ be a new built-in function object as defined in Observable.of Subscriber Functions.
-    1. Set _subscriber_'s [[Items]] internal slot to _items_.
+    1. Let _items_ be the List of arguments passed to this function.
+    1. Set _subscriber_.[[Items]] to _items_.
     1. Return Construct(_C_, « ‍_subscriber_ »).
   </emu-alg>
 
@@ -93,13 +101,16 @@
     <p>When an Observable.of subscriber function is called with argument _observer_, the following steps are taken:</p>
 
     <emu-alg>
-      1. Let _items_ be the value of the [[Items]] internal slot of _F_.
-      1. Let _subscription_ be the value of _observer_'s [[Subscription]] internal slot.      
+      1. Assert: _F_ has an [[Items]] internal slot whose value is a List.
+      1. If Type(_observer_) is not Object, throw a *TypeError* exception.
+      1. Let _items_ be _F_.[[Items]].
       1. For each element _value_ of _items_
-        1. Perform ! Invoke(_observer_, `"next"`, « ‍_value_ »).
-        1. If SubscriptionClosed(_subscription_) is *true*, then
-          1. Return *undefined*.
-      1. Perform ! Invoke(_observer_, `"complete"`, «‍ »).
+        1. Let _closed_ be ? ToBoolean(? GetV(_observer_, `"closed"`)).
+        1. If _closed_ is *true*, then return *undefined*.
+        1. Perform ? Invoke(_observer_, `"next"`, « ‍_value_ »).
+      1. Let _closed_ be ? ToBoolean(? GetV(_observer_, `"closed"`)).
+      1. If _closed_ is *true*, then return *undefined*.
+      1. Perform ? Invoke(_observer_, `"complete"`, « »).
       1. Return *undefined*.
     </emu-alg>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -9,6 +9,26 @@ copyright: false
 contributors: Kevin Smith
 </pre>
 
+<emu-clause id="warn-if-abrupt" aoid="WarnIfAbrupt">
+  <h1>WarnIfAbrupt ( _completion_, _result_ )</h1>
+
+  <p>WarnIfAbrupt is similar to ReturnIfAbrupt, but instead of propagating an error, it returns a value. For example, algorithm steps that say or are otherwise equivalent to:</p>
+
+  <emu-alg>
+    1. WarnIfAbrupt(_argument_, _value_).
+  </emu-alg>
+
+  <p>mean the same thing as:</p>
+
+  <emu-alg>
+    1. If _argument_ is abrupt, then
+      1. Perform HostReportErrors(« _argument_.[[Value]] »).
+      1. Return _value_.
+    1. Else,
+      1. Let _argument_ be _argument_.[[Value]].
+  </emu-alg>
+</emu-clause>
+
 <emu-clause id="observable-constructor">
   <h1>The Observable Constructor</h1>
 
@@ -28,8 +48,8 @@ contributors: Kevin Smith
     <emu-alg>
       1. If NewTarget is *undefined*, throw a *TypeError* exception.
       1. If IsCallable(_subscriber_) is *false*, throw a *TypeError* exception.
-      1. Let _observable_ be ? OrdinaryCreateFromConstructor(NewTarget, %ObservablePrototype%, «‍ [[Subscriber]] »).
-      1. Set _observable's_ [[Subscriber]] internal slot to _subscriber_.
+      1. Let _observable_ be ? OrdinaryCreateFromConstructor(NewTarget, %ObservablePrototype%, « [[Subscriber]] »).
+      1. Set _observable.[[Subscriber]] to _subscriber_.
       1. Return _observable_.
     </emu-alg>
   </emu-clause>

--- a/spec/prototype-properties.html
+++ b/spec/prototype-properties.html
@@ -97,3 +97,11 @@
 
   <p>The value of the `name` property of this function is `"[Symbol.observable]"`.</p>
 </emu-clause>
+
+<emu-clause id="observable-prototype-@@toStringTag">
+  <h1>Observable.prototype [ @@toStringTag ] ( )</h1>
+
+  <p>The initial value of the `@@toStringTag` property of `Observable.prototype` is the String value `"Observable"`.</p>
+
+  <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+</emu-clause>

--- a/spec/prototype-properties.html
+++ b/spec/prototype-properties.html
@@ -54,8 +54,7 @@
       1. Let _subscriberResult_ be ? Call(_subscriber_, *undefined*, _observer_).
       1. If _subscriberResult_ is *null* or *undefined*, return *undefined*.
       1. If IsCallable(_subscriberResult_) is *true*, return _subscriberResult_.
-      1. Let _result_ be ? GetMethod(_subscriberResult_, `"unsubscribe"`).
-      1. If _result_ is *undefined*, throw a *TypeError* exception.
+      1. If Type(_subscriberResult_) is not Object, throw a *TypeError* exception.
       1. Let _cleanupFunction_ be a new built-in function object as defined in Subscription Cleanup Functions.
       1. Set _cleanupFunction_.[[Subscription]] to _subscriberResult_.
       1. Return _cleanupFunction_.

--- a/spec/prototype-properties.html
+++ b/spec/prototype-properties.html
@@ -8,7 +8,7 @@
   <emu-alg>
     1. Let _O_ be the *this* value.
     1. If Type(_O_) is not Object, throw a *TypeError* exception.
-    1. If _O_ does not have an [[Subscriber]] internal slot, throw a *TypeError* exception.
+    1. If _O_ does not have all the internal slots of an Observable object, throw a *TypeError* exception.
     1. If IsCallable(_observer_) is *true*, then
       1. Let _len_ be the actual number of arguments passed to this function.
       1. Let _args_ be the List of arguments passed to this function.
@@ -23,24 +23,21 @@
       1. Perform ! CreateDataProperty(_observer_, `"complete"`, _completeCallback_).
     1. Else if Type(_observer_) is not Object, Let _observer_ be ObjectCreate(%ObjectPrototype%).
     1. Let _subscription_ be ? CreateSubscription(_observer_).
-    1. Let _startMethodResult_ be GetMethod(_observer_, `"start"`).
-    1. If _startMethodResult_.[[Type]] is ~normal~, then
-      1. Let _start_ be _startMethodResult_.[[Value]].
-      1. If _start_ is not *undefined*, then
-        1. Let _result_ be Call(_start_, _observer_, « _subscription_ »).
-        1. If _result_ is an abrupt completion, perform HostReportErrors(« _result_.[[Value]] »).
-        1. If SubscriptionClosed(_subscription_) is *true*, then
-          1. Return _subscription_.
-    1. Else if _startMethodResult_.[[Type]] is ~throw~, then perform HostReportErrors(« _startMethodResult_.[[Value]] »).
-    1. If _result_ is an abrupt completion, perform HostReportErrors(« _result_.[[Value]] »).
+    1. Let _start_ be GetMethod(_observer_, `"start"`).
+    1. WarnIfAbrupt(_start_, _subscription_).
+    1. If _start_ is not *undefined*, then
+      1. Let _result_ be Call(_start_, _observer_, « _subscription_ »).
+      1. WarnIfAbrupt(_result_, _subscription_).
+      1. If SubscriptionClosed(_subscription_) is *true*, then
+        1. Return _subscription_.
     1. Let _subscriptionObserver_ be ? CreateSubscriptionObserver(_subscription_).
-    1. Let _subscriber_ be the value of _O's_ [[Subscriber]] internal slot.
+    1. Let _subscriber_ be _O_.[[Subscriber]].
     1. Assert: IsCallable(_subscriber_) is *true*.
     1. Let _subscriberResult_ be ExecuteSubscriber(_subscriber_, _subscriptionObserver_).
     1. If _subscriberResult_ is an abrupt completion, then
-      1. Perform ! Invoke(_subscriptionObserver_, `"error"`, « ‍_subscriberResult_.[[value]] »).
+      1. Perform ! EmitSubscriptionHook(_subscriptionObserver_, `"error"`, ‍_subscriberResult_.[[value]]).
     1. Else,
-      1. Set the [[Cleanup]] internal slot of _subscription_ to _subscriberResult_.[[value]].
+      1. Set _subscription_.[[Cleanup]] to _subscriberResult_.[[value]].
     1. If SubscriptionClosed(_subscription_) is *true*, then
       1. Perform ! CleanupSubscription(_subscription_).
     1. Return _subscription_.
@@ -60,7 +57,7 @@
       1. Let _result_ be ? GetMethod(_subscriberResult_, `"unsubscribe"`).
       1. If _result_ is *undefined*, throw a *TypeError* exception.
       1. Let _cleanupFunction_ be a new built-in function object as defined in Subscription Cleanup Functions.
-      1. Set _cleanupFunction_'s [[Subscription]] internal slot to _subscriberResult_.
+      1. Set _cleanupFunction_.[[Subscription]] to _subscriberResult_.
       1. Return _cleanupFunction_.
     </emu-alg>
   </emu-clause>
@@ -73,8 +70,8 @@
     <p>When a subscription cleanup function _F_ is called the following steps are taken:</p>
 
     <emu-alg>
-      1. Assert: _F_ as a [[Subscription]] internal slot whose value is an Object.
-      1. Let _subscription_ be the value of _F_'s [[Subscription]] internal slot.
+      1. Assert: _F_ has a [[Subscription]] internal slot whose value is an Object.
+      1. Let _subscription_ be _F_.[[Subscription]].
       1. Return Invoke(_subscription_, `"unsubscribe"`, « ‍»).
     </emu-alg>
 

--- a/spec/subscription-observer.html
+++ b/spec/subscription-observer.html
@@ -92,4 +92,12 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="subscription-observer-prototype-@@toStringTag">
+    <h1>%SubscriptionObserverPrototype% [ @@toStringTag ] ( )</h1>
+
+    <p>The initial value of the `@@toStringTag` property of %SubscriptionObserverPrototype% is the String value `"Subscription Observer"`.</p>
+
+    <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+  </emu-clause>
+
 </emu-clause>

--- a/spec/subscription-observer.html
+++ b/spec/subscription-observer.html
@@ -9,8 +9,36 @@
     <emu-alg>
       1. Assert: Type(_subscription_) is Object.
       1. Let _subscriptionObserver_ be ObjectCreate(%SubscriptionObserverPrototype%, «‍ [[Subscription]] »).
-      1. Set _subscriptionObserver_'s [[Subscription]] internal slot to _subscription_.
+      1. Set _subscriptionObserver_.[[Subscription]] to _subscription_.
       1. Return _subscriptionObserver_.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="emit-subscription-error" aoid="EmitSubscriptionError">
+    <h1>EmitSubscriptionHook ( _O_, _methodName_ [ , _value_ ] )</h1>
+
+    <p>The abstract operation EmitSubscriptionHook with arguments _O_, _methodName_, and optional _value_ is used to invoke method on a given subscriber's observer.  It performs the following steps:</p>
+
+    <emu-alg>
+      1. Assert: Type(_O_) is Object.
+      1. Assert: _O_ is a Subscription Observer instance.
+      1. Assert: Type(_methodName_) is either `"next"`, `"error"`, or `"complete"`.
+      1. Assert: _args_ is a List.
+      1. Let _subscription_ be _O_.[[Subscription]].
+      1. If SubscriptionClosed(_subscription_) is *true*, return *undefined*.
+      1. Let _observer_ be _subscription_.[[Observer]].
+      1. If _methodName_ is not `"next"`, then
+        1. Set _subscription_.[[Observer]] to *undefined*.
+      1. Assert: Type(_observer_) is Object.
+      1. Let _method_ be GetMethod(_observer_, _methodName_).
+      1. WarnIfAbrupt(_method_, *undefined*).
+      1. If _method_ is not *undefined*, then
+        1. If _value_ is present, let _args_ be « value »; otherwise, let _args_ be the empty list.
+        1. Let _result_ be Call(_method_, _observer_, _args).
+        1. WarnIfAbrupt(_result_, *undefined*).
+      1. If _methodName_ is not `"next"`, then
+        1. Perform ! CleanupSubscription(_subscription_).
+      1. Return *undefined*.
     </emu-alg>
   </emu-clause>
 </emu-clause>
@@ -26,7 +54,7 @@
       1. Let _O_ be the *this* value.
       1. If Type(_O_) is not Object, throw a *TypeError* exception.
       1. If _O_ does not have all of the internal slots of a Subscription Observer instance, throw a *TypeError* exception.
-      1. Let _subscription_ be the value of _O_'s [[Subscription]] internal.
+      1. Let _subscription_ be _O_.[[Subscription]].
       1. Return ! SubscriptionClosed(_subscription_).
     </emu-alg>
   </emu-clause>
@@ -37,17 +65,7 @@
       1. Let _O_ be the *this* value.
       1. If Type(_O_) is not Object, throw a *TypeError* exception.
       1. If _O_ does not have all of the internal slots of a Subscription Observer instance, throw a *TypeError* exception.
-      1. Let _subscription_ be the value of _O_'s [[Subscription]] internal slot.
-      1. If SubscriptionClosed(_subscription_) is *true*, return *undefined*.
-      1. Let _observer_ be the value of _subscription_'s [[Observer]] internal slot.
-      1. Assert: Type(_observer_) is Object.
-      1. Let _nextMethodResult_ be GetMethod(_observer_, `"next"`).
-      1. If _nextMethodResult_.[[Type]] is ~normal~, then
-        1. Let _nextMethod_ be _nextMethodResult_.[[Value]].
-        1. If _nextMethod_ is not *undefined*, then
-          1. Let _result_ be Call(_nextMethod_, _observer_, « ‍_value_ »).
-          1. If _result_ is an abrupt completion, perform HostReportErrors(« _result_.[[Value]] »).
-      1. Else if _nextMethodResult_.[[Type]] is ~throw~, then perform HostReportErrors(« _nextMethodResult_.[[Value]] »).
+      1. Perform ! EmitSubscriptionHook(_O_, `"next"`, _value_).
       1. Return *undefined*.
     </emu-alg>
   </emu-clause>
@@ -58,19 +76,7 @@
       1. Let _O_ be the *this* value.
       1. If Type(_O_) is not Object, throw a *TypeError* exception.
       1. If _O_ does not have all of the internal slots of a Subscription Observer instance, throw a *TypeError* exception.
-      1. Let _subscription_ be the value of _O_'s [[Subscription]] internal slot.
-      1. If SubscriptionClosed(_subscription_) is *true*, return *undefined*.
-      1. Let _observer_ be the value of _subscription_'s [[Observer]] internal slot.
-      1. Set _subscription_'s [[Observer]] internal slot to *undefined*.
-      1. Assert: Type(_observer_) is Object.
-      1. Let _errorMethodResult_ be GetMethod(_observer_, `"error"`).
-      1. If _errorMethodResult_.[[Type]] is ~normal~, then
-        1. Let _errorMethod_ be _errorMethodResult_.[[Value]].
-        1. If _errorMethod_ is not *undefined*, then
-          1. Let _result_ be Call(_errorMethod_, _observer_, « _exception_ »).
-          1. If _result_ is an abrupt completion, perform HostReportErrors(« _result_.[[Value]] »).
-      1. Else if _errorMethodResult_.[[Type]] is ~throw~, then perform HostReportErrors(« _errorMethodResult_.[[Value]] »).
-      1. Perform ! CleanupSubscription(_subscription_).
+      1. Perform ! EmitSubscriptionHook(_O_, `"error"`, _value_).
       1. Return *undefined*.
     </emu-alg>
   </emu-clause>
@@ -81,19 +87,7 @@
       1. Let _O_ be the *this* value.
       1. If Type(_O_) is not Object, throw a *TypeError* exception.
       1. If _O_ does not have all of the internal slots of a Subscription Observer instance, throw a *TypeError* exception.
-      1. Let _subscription_ be the value of _O_'s [[Subscription]] internal slot.
-      1. If SubscriptionClosed(_subscription_) is *true*, return *undefined*.
-      1. Let _observer_ be the value of _subscription_'s [[Observer]] internal slot.
-      1. Set _subscription_'s [[Observer]] internal slot to *undefined*.
-      1. Assert: Type(_observer_) is Object.
-      1. Let _completeMethodResult_ be GetMethod(_observer_, `"complete"`).
-      1. If _completeMethodResult_.[[Type]] is ~normal~, then
-        1. Let _completeMethod_ be _completeMethodResult_.[[Value]].
-        1. If _completeMethod_ is not *undefined*, then
-          1. Let _result_ be Call(_completeMethod_, _observer_).
-          1. If _result_ is an abrupt completion, perform HostReportErrors(« _result_.[[Value]] »).
-      1. Else if _completeMethodResult_.[[Type]] is ~throw~, then perform HostReportErrors(« _completeMethodResult_.[[Value]] »).
-      1. Perform ! CleanupSubscription(_subscription_).
+      1. Perform ! EmitSubscriptionHook(_O_, `"complete"`).
       1. Return *undefined*.
     </emu-alg>
   </emu-clause>

--- a/spec/subscription.html
+++ b/spec/subscription.html
@@ -72,4 +72,12 @@
       1. Return CleanupSubscription(_subscription_).
     </emu-alg>
   </emu-clause>
+
+  <emu-clause id="subscription-prototype-@@toStringTag">
+      <h1>%SubscriptionPrototype% [ @@toStringTag ] ( )</h1>
+
+      <p>The initial value of the `@@toStringTag` property of %SubscriptionPrototype% is the String value `"Subscription"`.</p>
+
+      <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+  </emu-clause>
 </emu-clause>

--- a/spec/subscription.html
+++ b/spec/subscription.html
@@ -9,8 +9,8 @@
     <emu-alg>
       1. Assert: Type(_observer_) is Object.
       1. Let _subscription_ be ObjectCreate(%SubscriptionPrototype%, «‍ [[Observer]], [[Cleanup]] »).
-      1. Set _subscription_'s [[Observer]] internal slot to _observer_.
-      1. Set _subscription_'s [[Cleanup]] internal slot to *undefined*.
+      1. Set _subscription_.[[Observer]] to _observer_.
+      1. Set _subscription_.[[Cleanup]] to *undefined*.
       1. Return _subscription_.
     </emu-alg>
   </emu-clause>
@@ -22,12 +22,12 @@
 
     <emu-alg>
       1. Assert: _subscription_ is a Subscription object.
-      1. Let _cleanup_ be the value of _subscription_'s [[Cleanup]] internal slot.
+      1. Let _cleanup_ be _subscription_.[[Cleanup]].
       1. If _cleanup_ is *undefined*, return *undefined*.
       1. Assert: IsCallable(_cleanup_) is *true*.
-      1. Set _subscription_'s [[Cleanup]] internal slot to *undefined*.
+      1. Set _subscription_.[[Cleanup]] to *undefined*.
       1. Let _result_ be Call(_cleanup_, *undefined*, «‍ »).
-      1. If _result_ is an abrupt completion, perform HostReportErrors(« _result_.[[Value]] »).
+      1. WarnIfAbrupt(_result_, *undefined*).
       1. Return *undefined*.
     </emu-alg>
   </emu-clause>
@@ -39,7 +39,7 @@
 
     <emu-alg>
       1. Assert: _subscription_ is a Subscription object.
-      1. If the value of _subscription_'s [[Observer]] internal slot is *undefined*, return *true*.
+      1. If _subscription_.[[Observer]] is *undefined*, return *true*.
       1. Else, return *false*.
     </emu-alg>
   </emu-clause>
@@ -68,7 +68,7 @@
       1. If Type(_subscription_) is not Object, throw a *TypeError* exception.
       1. If _subscription_ does not have all of the internal slots of a Subscription instance, throw a *TypeError* exception.
       1. If SubscriptionClosed(_subscription_) is *true*, return *undefined*.
-      1. Set _subscription_'s [[Observer]] internal slot to *undefined*.
+      1. Set _subscription_.[[Observer]] to *undefined*.
       1. Return CleanupSubscription(_subscription_).
     </emu-alg>
   </emu-clause>


### PR DESCRIPTION
Fixes: #197 
Fixes: #196 
Fixes: #186 
Fixes: #184 
Fixes: #176 
Fixes: #165 
Fixes: #91 

This doesn't *yet* include updated tests, but I did update the spec.

I purposefully tried to leave out spec changes/fixes that might be controversial, like [changing/removing the 3-arg `subscribe` variant](https://github.com/tc39/proposal-observable/issues/194) or [not swallowing errors](https://github.com/tc39/proposal-observable/issues/195). But here's a list of what I did fix (I think this is all):

- I fixed a slew of erroneous non-throwing assertions.
- I fixed a few typos, formatting errors, and other related mistakes and inconsistencies.
- I fixed `Observable.from` to correctly use @\@iterator for the iterable case.
- I edited the "HostReportErrors" stuff to just use a common shorthand instead, so it's a bit more readable and intelligible, and to fix a few inconsistencies. Implementations are likely to just use a macro or do what polyfill writers do and desugar them into try/catch blocks.
- I merged the `next`/`error`/`complete` operations to just use variants of the same core algorithm. I also used it to replace the erroneous object method call within `Observable.prototype.subscribe`. This simplified the spec tremendously without loss of clarity.
- I added quite a few spec assertions over internal slots and their types, for clarity.
- I fixed the type checks that went "if *O* does not have **the [[Foo]] internal slot**" to read "if *O* does not have **all of the internal slots of Bar objects**" instead, for consistency and clarity.
- I fixed all the subscription observer callbacks for `Observable.from` and `Observable.of` to 1. type-check their input, and 2. work on their arguments generically instead of assuming they're subscription observers.
- I added @\@toStringTag support for the various types (observable, subscription, and subscription observer).
- I elected to [defer the `unsubscribe` method check](https://github.com/tc39/proposal-observable/issues/176) instead of accessing it twice. I still maintained the object check so engines can avoid handling nonsensical cases.
- I changed all the internal slot accesses to match the mainline spec - it's way more concise.
- I fixed a lot of consistency issues within the README and clarified a few things with (usually) added annotations. I also changed it to use TypeScript highlighting, so it's less likely to be odd and unusual in editors.

I'm aware it reads a bit like shotgun surgery, but when I was trying to write an optimized implementation of this (with JIT-compiled pipelines), trying to figure out the behavior I needed to maintain required so many explicit spec deviations I decided my time was better spent fixing the spec so I *could* do the experiment. And yes, a lot of things needed fixed.